### PR TITLE
Cast `:sources` to set to support EDN

### DIFF
--- a/src/hiera/main.clj
+++ b/src/hiera/main.clj
@@ -192,7 +192,7 @@
   map of options."
   [opts]
   (let [opts (merge defaults opts)
-        source-files (find-sources (:sources opts))
+        source-files (find-sources (set (:sources opts)))
         data (assoc opts
                     :namespaces (file-namespaces source-files)
                     :graph (file-deps source-files))]


### PR DESCRIPTION
`:sources` is a set, and sets aren't supported in EDN (e.g. `:exec-args` in `deps.edn`), so we call `clojure.core/set` on `:sources` before we use it so it can be set as e.g. a vector.